### PR TITLE
exit with failure code on prettier error

### DIFF
--- a/zoe/src/zoe.ts
+++ b/zoe/src/zoe.ts
@@ -23,12 +23,16 @@ const { flags, pkg, input } = meow(help, {
 });
 
 async function lint(): Promise<void> {
-	process.exitCode = 0;
-
 	// Zoe x.x.x
 	log(zoe, pkg.version);
 
 	const results = engine(input, flags.fix);
+	const { errorCount } = results.report;
+	let exitCode = 0;
+	if (errorCount > 0) {
+		exitCode = 1;
+	}
+	process.exitCode = exitCode;
 	logger(results, flags.fix, flags.verbose);
 }
 


### PR DESCRIPTION
Zoe should exit with failure code on prettier error.
Not doing so disturb any Git hook library
(like [husky](https://github.com/typicode/husky)), which depend
on the linting to return an error for the hooks to fail or not.

Like the way it was Zoe always returned with a success code,
precommit were always passing, even when there were prettier errors.
Which is an undesirable effect. Or, at least, I don't want it: what is the sense of having prettier checking the code if it allows to commit with such errors? It renders precommit useless :(.